### PR TITLE
ci: disable verbose logging in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,3 +18,6 @@ steps:
         '--platform', 'managed',
         '--allow-unauthenticated'
       ]
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Reduce log verbosity to only show cloud logging and improve readability